### PR TITLE
fix bash script not to include 'source:' from next file in filtered url

### DIFF
--- a/src/test/resources/fetch-booster-bundles.sh
+++ b/src/test/resources/fetch-booster-bundles.sh
@@ -14,7 +14,7 @@ done
 git bundle create booster-catalog.bundle --all
 cp booster-catalog.bundle ${TEST_DIR}
 
-for repo in $(cat $(find . -type f -name '*.yaml') | grep url | sed -e 's/^[ \t]*//' | cut -f2 -d' '); do
+for repo in $(tail -n +1 $(find . -type f -name '*.yaml') | grep url | sed -e 's/^[ \t]*//' | cut -f2 -d' '); do
     cd ${BOOSTER_TMP_DIR}
     mkdir -p repos
     cd repos


### PR DESCRIPTION
**Previous Command**
`cat $(find . -type f -name '*.yaml') | grep url | sed -e 's/^[ \t]*//' | cut -f2 -d' '`

**Output**
```bash
https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-health-check-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-health-check
https://github.com/snowdrop/spring-boot-health-check-boostersource:
https://github.com/bucharest-gold/nodejs-health-check
https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-configmap-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-configmap
https://github.com/snowdrop/spring-boot-configmap-booster
https://github.com/bucharest-gold/nodejs-configmap
https://github.com/openshiftio-vertx-boosters/vertx-http-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-http-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http
https://github.com/snowdrop/spring-boot-http-boostersource:
https://github.com/bucharest-gold/nodejs-rest-http
https://github.com/openshiftio-vertx-boosters/vertx-crud-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-crud-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-crud-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-crud
https://github.com/snowdrop/spring-boot-crud-boostersource:
https://github.com/bucharest-gold/nodejs-rest-http-crud
https://github.com/jboss-fuse/fuse-springboot-circuit-breaker-booster
https://github.com/openshiftio-vertx-boosters/vertx-circuit-breaker-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-circuit-breaker-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-circuit-breaker-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-circuit-breaker
https://github.com/snowdrop/spring-boot-circuit-breaker-boostersource:
https://github.com/bucharest-gold/nodejs-circuit-breaker
https://github.com/openshiftio-vertx-boosters/vertx-secured-http-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-secured-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-secured
https://github.com/snowdrop/spring-boot-http-secured-boostersource:
https://github.com/bucharest-gold/nodejs-rest-http-secured
```
This command is adding `source:` for some spring-boot booster due to missing end of file.

**Updated Command**
`tail -n +1 $(find . -type f -name '*.yaml') | grep url | sed -e 's/^[ \t]*//' | cut -f2 -d' '`

**Output**
```bash
https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-health-check-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-health-check
https://github.com/snowdrop/spring-boot-health-check-booster
https://github.com/bucharest-gold/nodejs-health-check
https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-configmap-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-configmap
https://github.com/snowdrop/spring-boot-configmap-booster
https://github.com/bucharest-gold/nodejs-configmap
https://github.com/openshiftio-vertx-boosters/vertx-http-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-http-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http
https://github.com/snowdrop/spring-boot-http-booster
https://github.com/bucharest-gold/nodejs-rest-http
https://github.com/openshiftio-vertx-boosters/vertx-crud-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-crud-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-crud-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-crud
https://github.com/snowdrop/spring-boot-crud-booster
https://github.com/bucharest-gold/nodejs-rest-http-crud
https://github.com/jboss-fuse/fuse-springboot-circuit-breaker-booster
https://github.com/openshiftio-vertx-boosters/vertx-circuit-breaker-booster-redhat
https://github.com/openshiftio-vertx-boosters/vertx-circuit-breaker-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-circuit-breaker-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-circuit-breaker
https://github.com/snowdrop/spring-boot-circuit-breaker-booster
https://github.com/bucharest-gold/nodejs-circuit-breaker
https://github.com/openshiftio-vertx-boosters/vertx-secured-http-booster
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-secured-redhat
https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http-secured
https://github.com/snowdrop/spring-boot-http-secured-booster
https://github.com/bucharest-gold/nodejs-rest-http-secured
```
