### PR TITLE
fix(config): use default environment when empty

### DIFF
--- a/src/main/java/io/fabric8/launcher/booster/catalog/LauncherConfiguration.java
+++ b/src/main/java/io/fabric8/launcher/booster/catalog/LauncherConfiguration.java
@@ -28,6 +28,19 @@ public class LauncherConfiguration {
     }
 
     private static String getEnvVarOrSysProp(String name, String defaultValue) {
-        return System.getProperty(name, System.getenv().getOrDefault(name, defaultValue));
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("env var or sysprop name is required");
+        }
+        if (defaultValue == null || defaultValue.isEmpty()) {
+            throw new IllegalArgumentException("default value for " + name + " is required");
+        }
+        String value = System.getProperty(name);
+        if (value == null || value.isEmpty()) {
+            value = System.getenv(name);
+        }
+        if (value != null && value.isEmpty()) {
+            value = null;
+        }
+        return value != null ? value : defaultValue;
     }
 }


### PR DESCRIPTION
When using `docker run -e XX=$XX`

if `$XX` is not set, it set it to an empty string in the container.
This commit change the logic in order to make default value work when the environment is empty.