### PR TITLE
fix: fixed NPE when metadata is empty in a booster.yaml file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jboss</groupId>
@@ -18,6 +19,13 @@
   </licenses>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Do not reuse forks since system properties are changed in tests -->
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>

--- a/src/main/java/io/fabric8/launcher/booster/catalog/Booster.java
+++ b/src/main/java/io/fabric8/launcher/booster/catalog/Booster.java
@@ -257,7 +257,10 @@ public class Booster {
      */
     @SuppressWarnings("unchecked")
     public Map<String, Object> getMetadata() {
-        return data.containsKey(KEY_METADATA) ? Collections.unmodifiableMap((Map<String, Object>) data.get(KEY_METADATA)) : Collections.emptyMap();
+        Map<String, Object> metadata = (Map<String, Object>) data.get(KEY_METADATA);
+        return metadata != null ?
+                Collections.unmodifiableMap(metadata) :
+                Collections.emptyMap();
     }
 
     /**

--- a/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
+++ b/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
@@ -7,16 +7,6 @@
 
 package io.fabric8.launcher.booster.catalog;
 
-import io.fabric8.launcher.booster.catalog.BoosterCatalogService.Builder;
-import io.fabric8.launcher.booster.catalog.spi.NativeGitBoosterCatalogPathProvider;
-import org.arquillian.smart.testing.rules.git.server.GitServer;
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ProvideSystemProperty;
-
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -25,8 +15,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import io.fabric8.launcher.booster.catalog.BoosterCatalogService.Builder;
+import io.fabric8.launcher.booster.catalog.spi.NativeGitBoosterCatalogPathProvider;
+import org.arquillian.smart.testing.rules.git.server.GitServer;
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,7 +41,7 @@ public class BoosterCatalogServiceTest {
 
     @Rule
     public final ProvideSystemProperty launcherProperties = new ProvideSystemProperty(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REPOSITORY, "http://localhost:8765/booster-catalog/")
-                        .and(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF, "master");
+            .and(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF, "master");
 
     @Rule
     public final JUnitSoftAssertions softly = new JUnitSoftAssertions();

--- a/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
+++ b/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
@@ -27,7 +27,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,9 +38,6 @@ public class BoosterCatalogServiceTest {
             .fromBundle("gastaldi-booster-catalog", "repos/custom-catalogs/gastaldi-booster-catalog.bundle")
             .usingPort(8765)
             .create();
-
-    @ClassRule
-    public static final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     @Rule
     public final JUnitSoftAssertions softly = new JUnitSoftAssertions();

--- a/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
+++ b/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
@@ -23,10 +23,11 @@ import io.fabric8.launcher.booster.catalog.BoosterCatalogService.Builder;
 import io.fabric8.launcher.booster.catalog.spi.NativeGitBoosterCatalogPathProvider;
 import org.arquillian.smart.testing.rules.git.server.GitServer;
 import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,19 +36,24 @@ public class BoosterCatalogServiceTest {
 
     @ClassRule
     public static GitServer gitServer = GitServer.bundlesFromDirectory("repos/boosters")
-            .fromBundle("gastaldi-booster-catalog","repos/custom-catalogs/gastaldi-booster-catalog.bundle")
+            .fromBundle("gastaldi-booster-catalog", "repos/custom-catalogs/gastaldi-booster-catalog.bundle")
             .usingPort(8765)
             .create();
 
-    @Rule
-    public final ProvideSystemProperty launcherProperties = new ProvideSystemProperty(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REPOSITORY, "http://localhost:8765/booster-catalog/")
-            .and(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF, "master");
+    @ClassRule
+    public static final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     @Rule
     public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     @Nullable
     private static BoosterCatalogService defaultService;
+
+    @BeforeClass
+    public static void setUpSystemProperties() {
+        System.setProperty(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REPOSITORY, "http://localhost:8765/booster-catalog/");
+        System.setProperty(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF, "master");
+    }
 
     @Test
     public void testIndex() throws Exception {
@@ -277,7 +283,7 @@ public class BoosterCatalogServiceTest {
         assert (index >= 0 && index < path.size());
         return path.get(index);
     }
-    
+
     private BoosterCatalogService buildDefaultCatalogService() {
         if (defaultService == null) {
             defaultService = new Builder()
@@ -286,10 +292,10 @@ public class BoosterCatalogServiceTest {
         }
         return defaultService;
     }
-    
+
     private class TestRepoUrlFixer implements BoosterDataTransformer {
         private final String fixedUrl;
-        
+
         public TestRepoUrlFixer(String fixedUrl) {
             this.fixedUrl = fixedUrl;
         }

--- a/src/test/java/io/fabric8/launcher/booster/catalog/NullPointerExceptionBoosterTest.java
+++ b/src/test/java/io/fabric8/launcher/booster/catalog/NullPointerExceptionBoosterTest.java
@@ -1,0 +1,49 @@
+package io.fabric8.launcher.booster.catalog;
+
+import java.util.Optional;
+
+import io.fabric8.launcher.booster.catalog.rhoar.Mission;
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBoosterCatalogService;
+import io.fabric8.launcher.booster.catalog.rhoar.Runtime;
+import io.fabric8.launcher.booster.catalog.rhoar.Version;
+import org.arquillian.smart.testing.rules.git.server.GitServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static io.fabric8.launcher.booster.catalog.rhoar.BoosterPredicates.withMission;
+import static io.fabric8.launcher.booster.catalog.rhoar.BoosterPredicates.withRuntime;
+import static io.fabric8.launcher.booster.catalog.rhoar.BoosterPredicates.withVersion;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class NullPointerExceptionBoosterTest {
+
+    @ClassRule
+    public static GitServer gitServer = GitServer
+            .fromBundle("empty-metadata-booster-catalog", "repos/custom-catalogs/empty-metadata-booster-catalog.bundle")
+            .usingAnyFreePort()
+            .create();
+
+    @Test
+    public void should_not_throw_null_pointer_exception() throws Exception {
+        RhoarBoosterCatalogService service = new RhoarBoosterCatalogService.Builder()
+                .catalogRepository("http://localhost:" + gitServer.getPort() + "/empty-metadata-booster-catalog/")
+                .catalogRef("master")
+                .build();
+        // Wait for index to complete
+        service.index().get();
+        //  spring-boot/current-redhat/health-check
+        Optional<RhoarBooster> booster = service.getBooster(
+                withMission(new Mission("health-check"))
+                        .and(withRuntime(new Runtime("spring-boot")))
+                        .and(withVersion(new Version("current-redhat")))
+        );
+        assertThat(booster).hasValueSatisfying(b -> {
+            assertThatCode(() -> b.getMetadata()).doesNotThrowAnyException();
+        });
+    }
+}

--- a/src/test/resources/repos/custom-catalogs/empty-metadata-booster-catalog.bundle
+++ b/src/test/resources/repos/custom-catalogs/empty-metadata-booster-catalog.bundle
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0de9dde3357034eccfd8c9aa1891958c746b5798b648e805b160c133dbeee6f
+size 339488


### PR DESCRIPTION
An empty metadata tag causes the following exception:

```
Caused by: java.lang.NullPointerException
  | at java.util.Collections$UnmodifiableMap.<init>(Collections.java:1446)
  | at java.util.Collections.unmodifiableMap(Collections.java:1433)
  | at io.fabric8.launcher.booster.catalog.Booster.getMetadata(Booster.java:260)
  | at io.fabric8.launcher.web.endpoints.BoosterCatalogEndpoint.lambda$getRuntimes$0(BoosterCatalogEndpoint.java:110)
  | at java.util.Optional.ifPresent(Optional.java:159)
  | at io.fabric8.launcher.web.endpoints.BoosterCatalogEndpoint.getRuntimes(BoosterCatalogEndpoint.java:108)
  | at io.fabric8.launcher.web.endpoints.BoosterCatalogEndpoint$Proxy$_$$_WeldSubclass.getRuntimes(Unknown Source)
  | at io.fabric8.launcher.web.endpoints.BoosterCatalogEndpoint$Proxy$_$$_WeldClientProxy.getRuntimes(Unknown Source)
 

```