### PR TITLE
feat: handles multivalue filter parameters as OR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
   <properties>
     <version.junit>4.12</version.junit>
     <version.assertj>3.10.0</version.assertj>
+    <version.system.rules>1.18.0</version.system.rules>
     <version.git.rules>0.0.10</version.git.rules>
     <version.jsr305>3.0.2</version.jsr305>
     <version.snakeyaml>1.21</version.snakeyaml>
@@ -65,6 +66,12 @@
       <groupId>org.arquillian.smart.testing</groupId>
       <artifactId>git-rules</artifactId>
       <version>${version.git.rules}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>${version.system.rules}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/kotlin/io/fabric8/launcher/booster/catalog/rhoar/RhoarBooster.kt
+++ b/src/main/kotlin/io/fabric8/launcher/booster/catalog/rhoar/RhoarBooster.kt
@@ -1,9 +1,11 @@
 package io.fabric8.launcher.booster.catalog.rhoar
 
+import java.util.HashMap
+import java.util.Objects
+import java.util.stream.Collectors
+
 import io.fabric8.launcher.booster.catalog.Booster
 import io.fabric8.launcher.booster.catalog.BoosterFetcher
-import java.util.*
-import java.util.stream.Collectors
 
 class RhoarBooster : Booster {
     var mission: Mission? = null

--- a/src/main/kotlin/io/fabric8/launcher/booster/catalog/rhoar/RhoarBooster.kt
+++ b/src/main/kotlin/io/fabric8/launcher/booster/catalog/rhoar/RhoarBooster.kt
@@ -1,12 +1,9 @@
 package io.fabric8.launcher.booster.catalog.rhoar
 
-import java.util.Collections
-import java.util.HashMap
-import java.util.Objects
-import java.util.stream.Collectors
-
 import io.fabric8.launcher.booster.catalog.Booster
 import io.fabric8.launcher.booster.catalog.BoosterFetcher
+import java.util.*
+import java.util.stream.Collectors
 
 class RhoarBooster : Booster {
     var mission: Mission? = null

--- a/src/main/kotlin/io/fabric8/launcher/booster/catalog/rhoar/predicates/BoosterParameterPredicate.kt
+++ b/src/main/kotlin/io/fabric8/launcher/booster/catalog/rhoar/predicates/BoosterParameterPredicate.kt
@@ -2,7 +2,7 @@ package io.fabric8.launcher.booster.catalog.rhoar.predicates
 
 import io.fabric8.launcher.booster.catalog.Booster
 import org.apache.commons.beanutils.PropertyUtils
-import java.util.*
+import java.util.Objects
 import java.util.function.Predicate
 
 /**

--- a/src/main/kotlin/io/fabric8/launcher/booster/catalog/rhoar/predicates/BoosterParameterPredicate.kt
+++ b/src/main/kotlin/io/fabric8/launcher/booster/catalog/rhoar/predicates/BoosterParameterPredicate.kt
@@ -1,10 +1,9 @@
 package io.fabric8.launcher.booster.catalog.rhoar.predicates
 
-import java.util.Objects
-import java.util.function.Predicate
-
 import io.fabric8.launcher.booster.catalog.Booster
 import org.apache.commons.beanutils.PropertyUtils
+import java.util.*
+import java.util.function.Predicate
 
 /**
  * @author [George Gastaldi](mailto:ggastald@redhat.com)
@@ -12,15 +11,15 @@ import org.apache.commons.beanutils.PropertyUtils
 class BoosterParameterPredicate(private val parameters: Map<String, List<String>>) : Predicate<Booster> {
 
     override fun test(booster: Booster): Boolean {
-        var result = true
         for ((path, values) in parameters) {
-            val expectedValue = if (!values[0].isEmpty()) values[0] else "true"
-            if (!expectedValue.equals(getValueByPath(booster, path)!!, ignoreCase = true)) {
-                result = false
-                break
+            val actualValue = getValueByPath(booster, path)
+            val notFound = values.map { v -> if (!v.isEmpty()) v else "true" }
+                    .find { v -> v.equals(actualValue, true) }.orEmpty().isEmpty()
+            if (notFound) {
+                return false
             }
         }
-        return result
+        return true
     }
 
     private fun getValueByPath(b: Booster, path: String): String? {

--- a/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
+++ b/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
@@ -7,16 +7,6 @@
 
 package io.fabric8.launcher.booster.catalog;
 
-import io.fabric8.launcher.booster.catalog.BoosterCatalogService.Builder;
-import io.fabric8.launcher.booster.catalog.spi.NativeGitBoosterCatalogPathProvider;
-import org.arquillian.smart.testing.rules.git.server.GitServer;
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -26,6 +16,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import io.fabric8.launcher.booster.catalog.BoosterCatalogService.Builder;
+import io.fabric8.launcher.booster.catalog.spi.NativeGitBoosterCatalogPathProvider;
+import org.arquillian.smart.testing.rules.git.server.GitServer;
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import static io.fabric8.launcher.booster.catalog.LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF;
 import static io.fabric8.launcher.booster.catalog.LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REPOSITORY;

--- a/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
+++ b/src/test/java/io/fabric8/launcher/booster/catalog/BoosterCatalogServiceTest.java
@@ -7,6 +7,16 @@
 
 package io.fabric8.launcher.booster.catalog;
 
+import io.fabric8.launcher.booster.catalog.BoosterCatalogService.Builder;
+import io.fabric8.launcher.booster.catalog.spi.NativeGitBoosterCatalogPathProvider;
+import org.arquillian.smart.testing.rules.git.server.GitServer;
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -17,40 +27,38 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import javax.annotation.Nullable;
-
-import io.fabric8.launcher.booster.catalog.BoosterCatalogService.Builder;
-import io.fabric8.launcher.booster.catalog.spi.NativeGitBoosterCatalogPathProvider;
-import org.arquillian.smart.testing.rules.git.server.GitServer;
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.jetbrains.annotations.NotNull;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-
+import static io.fabric8.launcher.booster.catalog.LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF;
+import static io.fabric8.launcher.booster.catalog.LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REPOSITORY;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class BoosterCatalogServiceTest {
 
+    private static final String HOST = "http://localhost";
+
+    private static final int PORT = 8765;
+
+    private static final String CUSTOM_REPO = "gastaldi-booster-catalog";
+
+    private static final String CUSTOM_BOOSTER_CATALOG = HOST + ":" + PORT + "/" + CUSTOM_REPO;
+
     @ClassRule
-    public static GitServer gitServer = GitServer.bundlesFromDirectory("repos/boosters")
-            .fromBundle("gastaldi-booster-catalog", "repos/custom-catalogs/gastaldi-booster-catalog.bundle")
-            .usingPort(8765)
+    public static final GitServer gitServer = GitServer
+            .bundlesFromDirectory("repos/boosters")
+            .fromBundle(CUSTOM_REPO, "repos/custom-catalogs/gastaldi-booster-catalog.bundle")
+            .usingPort(PORT)
             .create();
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+            .set(LAUNCHER_BOOSTER_CATALOG_REPOSITORY, HOST + ":" + PORT + "/booster-catalog")
+            .set(LAUNCHER_BOOSTER_CATALOG_REF, "master");
 
     @Rule
     public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     @Nullable
     private static BoosterCatalogService defaultService;
-
-    @BeforeClass
-    public static void setUpSystemProperties() {
-        System.setProperty(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REPOSITORY, "http://localhost:8765/booster-catalog/");
-        System.setProperty(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF, "master");
-    }
 
     @Test
     public void testIndex() throws Exception {
@@ -90,7 +98,7 @@ public class BoosterCatalogServiceTest {
     @Test
     public void testCommonFiles() throws Exception {
         BoosterCatalogService service = new BoosterCatalogService.Builder()
-                .catalogRepository("http://localhost:8765/gastaldi-booster-catalog").catalogRef("common_test")
+                .catalogRepository(CUSTOM_BOOSTER_CATALOG).catalogRef("common_test")
                 .build();
         service.index().get();
 
@@ -107,7 +115,7 @@ public class BoosterCatalogServiceTest {
     @Test
     public void testMetadata() throws Exception {
         BoosterCatalogService service = new BoosterCatalogService.Builder()
-                .catalogRepository("http://localhost:8765/gastaldi-booster-catalog").catalogRef("common_test")
+                .catalogRepository(CUSTOM_BOOSTER_CATALOG).catalogRef("common_test")
                 .build();
         service.index().get();
 
@@ -125,7 +133,7 @@ public class BoosterCatalogServiceTest {
     @Test
     public void testIgnore() throws Exception {
         BoosterCatalogService service = new BoosterCatalogService.Builder()
-                .catalogRepository("http://localhost:8765/gastaldi-booster-catalog").catalogRef("ignore_test")
+                .catalogRepository(CUSTOM_BOOSTER_CATALOG).catalogRef("ignore_test")
                 .build();
         service.index().get();
 
@@ -137,7 +145,7 @@ public class BoosterCatalogServiceTest {
     @Test
     public void testManualEnvironment() throws Exception {
         BoosterCatalogService service = new BoosterCatalogService.Builder()
-                .catalogRepository("http://localhost:8765/gastaldi-booster-catalog").catalogRef("environments_test")
+                .catalogRepository(CUSTOM_BOOSTER_CATALOG).catalogRef("environments_test")
                 .build();
         service.index().get();
 
@@ -159,7 +167,7 @@ public class BoosterCatalogServiceTest {
     @Test
     public void testCatalogEnvironment() throws Exception {
         BoosterCatalogService service = new BoosterCatalogService.Builder()
-                .catalogRepository("http://localhost:8765/gastaldi-booster-catalog").catalogRef("environments_test")
+                .catalogRepository(CUSTOM_BOOSTER_CATALOG).catalogRef("environments_test")
                 .environment("production")
                 .build();
         service.index().get();
@@ -175,7 +183,7 @@ public class BoosterCatalogServiceTest {
     @Test
     public void testCatalogCompoundEnvironment() throws Exception {
         BoosterCatalogService service = new BoosterCatalogService.Builder()
-                .catalogRepository("http://localhost:8765/gastaldi-booster-catalog").catalogRef("environments_test")
+                .catalogRepository(CUSTOM_BOOSTER_CATALOG).catalogRef("environments_test")
                 .environment("production,extra")
                 .build();
         service.index().get();
@@ -284,7 +292,7 @@ public class BoosterCatalogServiceTest {
     private BoosterCatalogService buildDefaultCatalogService() {
         if (defaultService == null) {
             defaultService = new Builder()
-                    .transformer((new TestRepoUrlFixer("http://localhost:8765"))::transform)
+                    .transformer((new TestRepoUrlFixer(HOST + ":" + PORT))::transform)
                     .build();
         }
         return defaultService;
@@ -301,9 +309,9 @@ public class BoosterCatalogServiceTest {
             String gitRepo = Booster.getDataValue(data, "source/git/url", null);
             if (gitRepo != null) {
                 gitRepo = gitRepo.replace("https://github.com", fixedUrl);
-                Booster.setDataValue((Map<String, Object>)data, "source/git/url", gitRepo);
+                Booster.setDataValue(data, "source/git/url", gitRepo);
             }
-            return (Map<String, Object>)data;
+            return data;
         }
     }
 

--- a/src/test/java/io/fabric8/launcher/booster/catalog/rhoar/BoosterPredicatesTest.java
+++ b/src/test/java/io/fabric8/launcher/booster/catalog/rhoar/BoosterPredicatesTest.java
@@ -1,15 +1,20 @@
 package io.fabric8.launcher.booster.catalog.rhoar;
 
-import java.util.function.Predicate;
-
 import org.assertj.core.api.JUnitSoftAssertions;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
 import static io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster.checkCategory;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -21,7 +26,7 @@ public class BoosterPredicatesTest {
 
     @Test
     public void testCheckNegatableCategoryList() {
-        softly.assertThat(checkCategory(asList(), "foobar")).isTrue();
+        softly.assertThat(checkCategory(emptyList(), "foobar")).isTrue();
         softly.assertThat(checkCategory(asList("all"), "foobar")).isTrue();
         softly.assertThat(checkCategory(asList("foobar"), "foobar")).isTrue();
         softly.assertThat(checkCategory(asList("!foobar"), "foobar")).isFalse();
@@ -53,72 +58,87 @@ public class BoosterPredicatesTest {
     @Test
     public void script_should_evaluate_metadata_to_true() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withScriptFilter("booster.metadata.istio");
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("istio", "true"));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("istio", "true"));
         assertThat(predicate.test(booster)).isTrue();
     }
 
     @Test
     public void script_should_evaluate_metadata_to_false() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withScriptFilter("booster.metadata.istio");
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("istio", "false"));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("istio", "false"));
         assertThat(predicate.test(booster)).isFalse();
     }
 
     @Test
     public void params_default_vs_true_boolean() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withParameters(singletonMap("metadata.istio", singletonList("")));
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("istio", "true"));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("istio", "true"));
         assertThat(predicate.test(booster)).isTrue();
     }
 
     @Test
     public void params_nested_default_vs_true_boolean() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withParameters(singletonMap("metadata.osio.enabled", singletonList("")));
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("osio", singletonMap("enabled", "true")));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("osio", singletonMap("enabled", "true")));
         assertThat(predicate.test(booster)).isTrue();
     }
 
     @Test
     public void params_nested_true_vs_true_boolean() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withParameters(singletonMap("metadata.osio.enabled", singletonList("true")));
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("osio", singletonMap("enabled", "true")));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("osio", singletonMap("enabled", "true")));
         assertThat(predicate.test(booster)).isTrue();
     }
 
     @Test
     public void params_default_vs_false_boolean() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withParameters(singletonMap("metadata.istio", singletonList("")));
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("istio", "false"));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("istio", "false"));
         assertThat(predicate.test(booster)).isFalse();
     }
 
     @Test
     public void params_true_vs_true_boolean() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withParameters(singletonMap("metadata.istio", singletonList("true")));
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("istio", "true"));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("istio", "true"));
         assertThat(predicate.test(booster)).isTrue();
     }
 
     @Test
     public void params_true_vs_false_boolean() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withParameters(singletonMap("metadata.istio", singletonList("true")));
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("istio", "false"));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("istio", "false"));
         assertThat(predicate.test(booster)).isFalse();
+    }
+
+    @Test
+    public void should_filter_all_boosters_having_value_equal_to_one_of_multi_value_parameter() {
+        // given
+        Predicate<RhoarBooster> predicate = BoosterPredicates.withParameters(singletonMap("metadata.level", asList("novice", "advanced")));
+        RhoarBooster noviceBooster = boosterWithMetadata(singletonMap("level", "novice"));
+        RhoarBooster advancedBooster = boosterWithMetadata(singletonMap("level", "advanced"));
+        RhoarBooster expertBooster = boosterWithMetadata(singletonMap("level", "expert"));
+
+        final List<RhoarBooster> rhoarBoosters = asList(noviceBooster, advancedBooster, expertBooster);
+
+        // when
+        final List<RhoarBooster> filteredBoosters = rhoarBoosters.stream().filter(predicate).collect(toList());
+
+        // then
+        assertThat(filteredBoosters).containsOnly(noviceBooster, advancedBooster);
     }
 
     @Test
     public void params_not_exists() {
         Predicate<RhoarBooster> predicate = BoosterPredicates.withParameters(singletonMap("foo.bar", singletonList("")));
-        RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(singletonMap("dummy", "dummy"));
+        RhoarBooster booster = boosterWithMetadata(singletonMap("dummy", "dummy"));
         assertThat(predicate.test(booster)).isFalse();
+    }
+
+    @NotNull
+    private RhoarBooster boosterWithMetadata(Map<String, Object> metadata) {
+        RhoarBooster noviceBooster = mock(RhoarBooster.class);
+        when(noviceBooster.getMetadata()).thenReturn(metadata);
+        return noviceBooster;
     }
 }


### PR DESCRIPTION
Enables parameter filtering to handle multiple values, so I can query backend using for example `booster-catalog?metadata.level=novice&metadata.level=master`.