### PR TITLE
fix(readme): added Git LFS section

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -7,6 +7,13 @@ This project contains the service classes for the booster-catalog repository
 
 == Build and Run the Unit Tests
 
+* As we are using `git bundle`s to test Git operations using in-memory Git server we switched to [Git LFS](https://git-lfs.github.com/). Follow the instruction there to install on your machine. Once you have that set up, enable it for the repository:
+
+```bash
+$ git lfs install
+$ git lfs pull
+```
+
 * Execute:
 
         $ mvn clean install


### PR DESCRIPTION
### Why

We have introduced Git LFS to manage large files (such as bundles) easily. We missed, however, the description in the README on how to enable it, as it's not an integral part of the default git installation. Without that, all tests which rely on the bundles are failing, because bundles are just LFS pointers. 

### Description

Updates README with the required section
